### PR TITLE
Switch to DOM setInterval from node setInterval

### DIFF
--- a/router.ts
+++ b/router.ts
@@ -219,7 +219,7 @@ class Controller {
         } else if (this.wantsHashChange && (window.onhashchange != null)) {
             window.onhashchange = this.checkUrl
         } else if (this.wantsHashChange) {
-            this.checkUrlInterval = setInterval(this.checkUrl, this.interval)
+            this.checkUrlInterval = window.setInterval(this.checkUrl, this.interval)
         }
 
         this.fragment = this.getFragment()


### PR DESCRIPTION
Explicitly use `window.setInterval` instead of `setInterval` to avoid ambiguity, which causes the typescript compiler to fail if node types are present in the dependency tree.